### PR TITLE
fix issues of song-end animation could not handle mid-song fail (+ details)

### DIFF
--- a/System/Open-World Memories/Graphics/5_Game/9_End/AllPerfect/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/AllPerfect/Script.lua
@@ -23,8 +23,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Clear/Script.lua
@@ -17,7 +17,7 @@ local animeCounter = { 0, 0, 0, 0, 0 }
 local nowFrame = { 0, 0, 0, 0, 0 }
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Clear/Script.lua
@@ -18,6 +18,7 @@ local nowFrame = { 0, 0, 0, 0, 0 }
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/ClearFailed/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/ClearFailed/Script.lua
@@ -19,21 +19,30 @@ local textureCount = 32
 local frameRate = 24
 
 local allfailed = false
+local failed = { false, false, false, false, false }
 
 local templateMoyai_y = -1080
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
-    
-    if player == 0 then
-        allfailed = true
-    elseif isClear[player] then
-        allfailed = false
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
+    templateMoyai_y = -1080
+
+    -- must failed if reach here
+    failed[player + 1] = true
+    allfailed = true
+    for i = 1, 5 do
+        if not failed[i] then
+            allfailed = false
+            break
+        end
     end
 end
 
 function init()
+    -- reset for properly tracking all-failed status
+    allfailed = false
+    failed = { false, false, false, false, false }
 
     if playerCount <= 2 then
         y = { 216, 480, 0, 0, 0 }
@@ -58,7 +67,13 @@ function update(player)
 
     nowFrame[player + 1] = slideInFrame[player + 1] + fallFrame[player + 1]
 
-    if animeCounter[player + 1] > 1.1 and player == 0 then
+    -- only descend if all-failed
+    if player == 0 then
+        for i = 1, 5 do
+            if not (animeCounter[i] > 1.1) then
+                return
+            end
+        end
         templateMoyai_y = math.min(templateMoyai_y + (deltaTime * 5120), 0)
     end
 

--- a/System/Open-World Memories/Graphics/5_Game/9_End/FullCombo/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/FullCombo/Script.lua
@@ -14,8 +14,8 @@ local nowFrame = { 0, 0, 0, 0, 0 }
 local textureCount = 39
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/InPlay_Dropout/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/InPlay_Dropout/Script.lua
@@ -19,8 +19,8 @@ local textureCount = 1
 local frameRate = 24
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
@@ -19,8 +19,8 @@ local textureCount = 32
 local frameRate = 24
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
@@ -14,8 +14,8 @@ local nowFrame = { 0, 0, 0, 0, 0 }
 local textureCount = 39
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -17,7 +17,7 @@ local animeCounter = { 0, 0, 0, 0, 0 }
 local nowFrame = { 0, 0, 0, 0, 0 }
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -18,6 +18,7 @@ local nowFrame = { 0, 0, 0, 0, 0 }
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
+++ b/System/Open-World Memories/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
@@ -23,8 +23,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/Open-World Memories/SkinConfig.ini
+++ b/System/Open-World Memories/SkinConfig.ini
@@ -1,6 +1,6 @@
 ;Skin information
 Name=Open-World Memories V2: Gleaming Sky
-Version=0.6.0.27
+Version=0.6.0.28
 Creator=Dashy
 Resolution=1920,1080
 FontNameEN=Fonts/MPLUSRounded1c-Medium.ttf

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/AllPerfect/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/AllPerfect/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Clear/Script.lua
@@ -29,7 +29,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Clear/Script.lua
@@ -30,6 +30,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/ClearFailed/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/ClearFailed/Script.lua
@@ -23,8 +23,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Fail/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Fail/Script.lua
@@ -23,8 +23,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_FullCombo/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_FullCombo/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
@@ -29,7 +29,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
@@ -30,6 +30,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Perfect/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Gold_Perfect/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_FullCombo/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_FullCombo/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
@@ -29,7 +29,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
@@ -30,6 +30,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Perfect/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Dan_Red_Perfect/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/FullCombo/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/FullCombo/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
@@ -23,8 +23,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -29,7 +29,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -30,6 +30,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
+++ b/System/SimpleStyle (1080p)/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
@@ -21,8 +21,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle (1080p)/SkinConfig.ini
+++ b/System/SimpleStyle (1080p)/SkinConfig.ini
@@ -1,7 +1,7 @@
 ;スキンの情報設定
 ;Skin information
 Name=SimpleStyle (1080p)
-Version=0.6.0.6
+Version=0.6.0.7
 Creator=OpenTaiko Team(0AuBSQ, Takkkom)
 Resolution=1920,1080
 

--- a/System/SimpleStyle/Graphics/5_Game/9_End/AllPerfect/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/AllPerfect/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Clear/Script.lua
@@ -33,6 +33,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Clear/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Clear/Script.lua
@@ -32,7 +32,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/ClearFailed/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/ClearFailed/Script.lua
@@ -27,8 +27,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Fail/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Fail/Script.lua
@@ -27,8 +27,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_FullCombo/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_FullCombo/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
@@ -33,6 +33,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Pass/Script.lua
@@ -32,7 +32,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Perfect/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Gold_Perfect/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_FullCombo/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_FullCombo/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
@@ -33,6 +33,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Pass/Script.lua
@@ -32,7 +32,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Perfect/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Dan_Red_Perfect/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/FullCombo/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/FullCombo/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Tower_Dropout/Script.lua
@@ -27,8 +27,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_FullCombo/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -33,6 +33,7 @@ end
 
 function playEndAnime(player)
     animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Pass/Script.lua
@@ -32,7 +32,7 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
+++ b/System/SimpleStyle/Graphics/5_Game/9_End/Tower_TopReached_Perfect/Script.lua
@@ -25,8 +25,8 @@ function clearOut(player)
 end
 
 function playEndAnime(player)
-    animeCounter = { 0, 0, 0, 0, 0 }
-    nowFrame = { 0, 0, 0, 0, 0 }
+    animeCounter[player + 1] = 0
+    nowFrame[player + 1] = 0
 end
 
 function init()

--- a/System/SimpleStyle/SkinConfig.ini
+++ b/System/SimpleStyle/SkinConfig.ini
@@ -1,7 +1,7 @@
 ;スキンの情報設定
 ;Skin information
 Name=SimpleStyle
-Version=0.6.0.3
+Version=0.6.0.4
 Creator=OpenTaiko Team
 Resolution=1280,720
 


### PR DESCRIPTION
Fixes required by 0auBSQ/OpenTaiko#910.

* fix fail animation replayed when any other player also failed (in multiplay)
* fix Template Moyai appeared right when P1 failed in multiplay

Backward-compatible with 0.6.0.99 and below.